### PR TITLE
REST API- typo replace disv by div

### DIFF
--- a/rest-api-query/template.html
+++ b/rest-api-query/template.html
@@ -27,7 +27,7 @@
                         </button>
                     </uib-tab-heading>
                     <div class="card" style="margin-bottom: 5px;">
-                        <disv class="card-header" style="padding: 5px 10px;" ng-click="toggleQuery(tab)">
+                        <div class="card-header" style="padding: 5px 10px;" ng-click="toggleQuery(tab)">
                             <span translate="QUERY"></span>
                             <div class="pull-right">
                                 <a href ng-click="tab.hideQuery = !tab.hideQuery">


### PR DESCRIPTION
The REST API plugin was broken due to a typo in the template.html file:
![image](https://user-images.githubusercontent.com/25290041/48926488-8468b980-ef09-11e8-86d0-d5247cf84261.png)
